### PR TITLE
Add exit codes to rake task.

### DIFF
--- a/lib/scss_lint/rake_task.rb
+++ b/lib/scss_lint/rake_task.rb
@@ -29,12 +29,15 @@ module SCSSLint
       require 'scss_lint'
       require 'scss_lint/cli'
 
-      CLI.new.run([])
+      exit CLI.new.run([])
     rescue SystemExit => ex
-      if ex.status == CLI::EXIT_CODES[:data]
-        abort('scss-lint found lints')
+      if (ex.status == CLI::EXIT_CODES[:error] ||
+          ex.status == CLI::EXIT_CODES[:warning])
+        puts 'scss-lint found lints'
+        exit ex.status
       elsif ex.status != 0
-        abort('scss-lint failed with an error')
+        puts 'scss-lint failed with an error'
+        exit ex.status
       end
     end
   end

--- a/spec/scss_lint/rake_task_spec.rb
+++ b/spec/scss_lint/rake_task_spec.rb
@@ -13,8 +13,8 @@ describe SCSSLint::RakeTask do
       Rake::Task['scss_lint']
     end
 
-    it 'returns a successful exit code' do
-      expect(subject.invoke.first.call).to be_truthy
+    it 'raises error when no files are specified' do
+      lambda { subject.invoke.first.call }.should raise_error SystemExit
     end
   end
 end


### PR DESCRIPTION
I couldn't figure out how to mock a file correctly, so I don't have a positive test case. I did test this locally and it returns things as expected:

````
wli@oort:~/projects/test$ rake scss_lint
app/assets/stylesheets/test.scss:20 [W] SingleLinePerSelector: Each selector in a comma sequence should be on its own line
scss-lint found lints
wli@oort:~/projects/test$ echo $?
1
````