### PR TITLE
Add SelectorFormat convention for CSS Wizardry

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -105,7 +105,7 @@ linters:
 
   SelectorFormat:
     enabled: true
-    convention: hyphenated_lowercase # or 'BEM', or 'snake_case', or 'camel_case', or a regex pattern
+    convention: hyphenated_lowercase # or 'BEM', or 'BEM--CSS-Wizardry', or 'snake_case', or 'camel_case', or a regex pattern
 
   Shorthand:
     enabled: true

--- a/lib/scss_lint/linter/selector_format.rb
+++ b/lib/scss_lint/linter/selector_format.rb
@@ -67,6 +67,17 @@ module SCSSLint
           /x
         end,
       },
+      'BEM--CSS-Wizardry' => {
+        explanation: 'should be written in CSS Wizardry-flavored BEM (Block Element Modifier) format [http://csswizardry.com/2013/01/mindbemding-getting-your-head-round-bem-syntax/]',
+        validator: lambda do |name|
+          name =~ /
+            ^[a-z]([-]?[a-z0-9]+)*
+            (__[a-z0-9]([-]?[a-z0-9]+)*)?
+            (--[a-z0-9]([-]?[a-z0-9]+)*)?
+            (__[a-z0-9]([-]?[a-z0-9]+)*)?$
+          /x
+        end,
+      },
     }
 
     # Checks the given name and returns the violated convention if it failed.

--- a/spec/scss_lint/linter/selector_format_spec.rb
+++ b/spec/scss_lint/linter/selector_format_spec.rb
@@ -535,4 +535,80 @@ describe SCSSLint::Linter::SelectorFormat do
       it { should report_lint }
     end
   end
+
+  context 'when the BEM--CSS-Wizardry convention is specified' do
+    let(:linter_config) { { 'convention' => 'BEM--CSS-Wizardry' } }
+
+    context 'when a name contains no underscores or hyphens' do
+      let(:css) { '.block {}' }
+
+      it { should_not report_lint }
+    end
+
+    context 'when a name contains single hyphen' do
+      let(:css) { '.b-block {}' }
+
+      it { should_not report_lint }
+    end
+
+    context 'when a name contains multiple hyphens' do
+      let(:css) { '.b-block-name {}' }
+
+      it { should_not report_lint }
+    end
+
+    context 'when a name contains multiple hyphens in a row' do
+      let(:css) { '.b-block--modifier {}' }
+
+      it { should_not report_lint }
+    end
+
+    context 'when a name contains a single underscore' do
+      let(:css) { '.block_modifier {}' }
+
+      it { should report_lint }
+    end
+
+    context 'when a block has name-value modifier' do
+      let(:css) { '.block--modifier-value {}' }
+
+      it { should_not report_lint }
+    end
+
+    context 'when a block has name-value modifier with lots of hyphens' do
+      let(:css) { '.b-block-name--modifier-name-here-value-name-here {}' }
+
+      it { should_not report_lint }
+    end
+
+    context 'when a name has double underscores' do
+      let(:css) { '.b-block__element {}' }
+
+      it { should_not report_lint }
+    end
+
+    context 'when element goes after block with modifier' do
+      let(:css) { '.block--modifier-value__element {}' }
+
+      it { should_not report_lint }
+    end
+
+    context 'when element has modifier' do
+      let(:css) { '.block__element--modifier-value {}' }
+
+      it { should_not report_lint }
+    end
+
+    context 'when element has hypenated modifier' do
+      let(:css) { '.block__element--modifier {}' }
+
+      it { should_not report_lint }
+    end
+
+    context 'when element has hypenated paired modifier' do
+      let(:css) { '.block__element--modifier-value {}' }
+
+      it { should_not report_lint }
+    end
+  end
 end


### PR DESCRIPTION
CSS Wizardy has a variation on the BEM SelectorFormat which is different enough from the BEM standard to warrant a different validation regex.

http://csswizardry.com/2013/01/mindbemding-getting-your-head-round-bem-syntax/