### PR TITLE
Wrap at-declaratives in backticks

### DIFF
--- a/lib/scss_lint/linter/declaration_order.rb
+++ b/lib/scss_lint/linter/declaration_order.rb
@@ -15,8 +15,8 @@ module SCSSLint
 
     MESSAGE =
       'Rule sets should be ordered as follows: '\
-      '@extends, @includes without @content, ' \
-      'properties, @includes with @content, ' \
+      '`@extends`, `@includes` without `@content`, ' \
+      'properties, `@includes` with `@content`, ' \
       'nested rule sets'
 
     MIXIN_WITH_CONTENT = 'mixin_with_content'


### PR DESCRIPTION
We, at thoughtbot, use `scss-lint` to check for style violations in
[Hound][hound]. Hound will comment on style violations on an open PR,
and leave comments on the violating lines.

So to avoid pinging GitHub users in the comment, I suggest wrapping the
declaratives in backticks.