### PR TITLE
Add a new CheckStyle formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,27 @@ scss-lint --format=XML [scss-files...]
 </lint>
 ```
 
+### CheckStyle
+
+Outputs a CheckStyle XML with `<checkstyle>`, `<file>`, and `<error>` tags. Suitable for
+consumption by tools like [Jenkins](http://jenkins-ci.org/) with [CheckStyle plugin](https://wiki.jenkins-ci.org/display/JENKINS/Checkstyle+Plugin).
+
+```bash
+scss-lint --format=CheckStyle [scss-files...]
+```
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<checkstyle version="1.5.6">
+  <file name="test.css">
+    <error line="2" severity="warning" message="Prefer single quoted strings" />
+    <error line="2" severity="warning" message="Line should be indented 0 spaces, but was indented 1 spaces" />
+    <error line="5" severity="warning" message="Prefer single quoted strings" />
+    <error line="6" severity="warning" message="URLs should be enclosed in quotes" />
+  </file>
+</checkstyle>
+```
+
 ## Exit Status Codes
 
 `scss-lint` tries to use

--- a/lib/scss_lint/reporter/checkstyle_reporter.rb
+++ b/lib/scss_lint/reporter/checkstyle_reporter.rb
@@ -1,0 +1,33 @@
+module SCSSLint
+  # Reports lints in a CheckStyle format.
+  class Reporter::CheckStyleReporter < Reporter
+    def report_lints
+      output = '<?xml version="1.0" encoding="utf-8"?>'
+
+      output << '<checkstyle version="1.5.6">'
+      lints.group_by(&:filename).each do |filename, file_lints|
+        output << "<file name=#{filename.encode(xml: :attr)}>"
+
+        file_lints.each do |lint|
+          output << issue_tag(lint)
+        end
+
+        output << '</file>'
+      end
+      output << '</checkstyle>'
+
+      output
+    end
+
+  private
+
+    def issue_tag(lint)
+      "<error source=\"#{lint.linter.name if lint.linter}\" " \
+             "line=\"#{lint.location.line}\" " \
+             "column=\"#{lint.location.column}\" " \
+             "length=\"#{lint.location.length}\" " \
+             "severity=\"#{lint.severity}\" " \
+             "message=#{lint.description.encode(xml: :attr)} />"
+    end
+  end
+end

--- a/spec/scss_lint/reporter/checkstyle_reporter_spec.rb
+++ b/spec/scss_lint/reporter/checkstyle_reporter_spec.rb
@@ -1,0 +1,103 @@
+require 'spec_helper'
+
+describe SCSSLint::Reporter::CheckStyleReporter do
+  subject { SCSSLint::Reporter::CheckStyleReporter.new(lints) }
+
+  describe '#report_lints' do
+    let(:xml) { Nokogiri::XML(subject.report_lints) }
+
+    shared_examples_for 'XML document' do
+      it 'has an encoding of UTF-8' do
+        xml.encoding.should == 'utf-8'
+      end
+
+      it 'has an XML version of 1.0' do
+        xml.version.should == '1.0'
+      end
+
+      it 'contains a <checkstyle> root element' do
+        xml.root.name.should == 'checkstyle'
+      end
+    end
+
+    context 'when there are no lints' do
+      let(:lints) { [] }
+
+      it_should_behave_like 'XML document'
+    end
+
+    context 'when there are lints' do
+      let(:filenames)    { ['f1.scss', 'f2.scss', 'f1.scss'] }
+      # Include invalid XML characters in the third description to validate
+      # that escaping happens for preventing broken XML output
+      let(:descriptions) { ['lint 1', 'lint 2', 'lint 3 " \' < & >'] }
+      let(:severities)   { [:warning] * 3 }
+
+      let(:locations)    do
+        [
+          SCSSLint::Location.new(5,  2, 3),
+          SCSSLint::Location.new(7,  6, 2),
+          SCSSLint::Location.new(9, 10, 1)
+        ]
+      end
+
+      let(:lints) do
+        filenames.each_with_index.map do |filename, index|
+          SCSSLint::Lint.new(nil, filename, locations[index],
+                             descriptions[index], severities[index])
+        end
+      end
+
+      it_should_behave_like 'XML document'
+
+      it 'contains an <error> node for each lint' do
+        xml.xpath('//error').count.should == 3
+      end
+
+      it 'contains a <file> node for each file' do
+        xml.xpath('//file').map { |node| node[:name] }
+          .should =~ filenames.uniq
+      end
+
+      it 'contains <error> nodes grouped by <file>' do
+        xml.xpath('//file').map do |file_node|
+          file_node.xpath('./error').count
+        end.should =~ [1, 2]
+      end
+
+      it 'marks each issue with a line number' do
+        xml.xpath('//error[@line]').map { |node| node[:line] }
+          .should =~ locations.map { |location| location.line.to_s }
+      end
+
+      it 'marks each issue with a column number' do
+        xml.xpath('//error[@column]').map { |node| node[:column] }
+          .should =~ locations.map { |location| location.column.to_s }
+      end
+
+      it 'marks each issue with a length' do
+        xml.xpath('//error[@length]').map { |node| node[:length] }
+          .should =~ locations.map { |location| location.length.to_s }
+      end
+
+      it 'marks each issue with a message containing the lint description' do
+        xml.xpath('//error[@message]').map { |node| node[:message] }
+          .should =~ descriptions
+      end
+
+      context 'when lints are warnings' do
+        it 'marks each issue with a severity of "warning"' do
+          xml.xpath("//error[@severity='warning']").count == 3
+        end
+      end
+
+      context 'when lints are errors' do
+        let(:severities) { [:error] * 3 }
+
+        it 'marks each issue with a severity of "error"' do
+          xml.xpath("//error[@severity='error']").count == 3
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I have not found any Jenkins plugin which is suitable to process an XML which is generated by the `--format=XML` option.

This new formatter/reporter almost the same as the XML formatter only difference is that this produce a standard Checkstyle format.
