### PR TITLE
Add animation* properties to concentric.txt

### DIFF
--- a/data/property-sort-orders/concentric.txt
+++ b/data/property-sort-orders/concentric.txt
@@ -122,3 +122,12 @@ font-style
 
 content
 quotes
+
+animation
+animation-name
+animation-fill-mode
+animation-delay
+animation-duration
+animation-iteration-count
+animation-play-state
+animation-timing-function


### PR DESCRIPTION
    PropertySortOrder:
      order: concentric 

First suggests 

    Properties should be ordered animation-name, animation-fill-mode

So one updates the order, it then suggests

    Properties should be ordered animation-fill-mode, animation-name

This is an infinite loop (assuming the human doesn't notice, lol).

Upon inspection, the animation rules are missing from the contentric.txt setting, this PR adds them.

Using the `animation` shorthand as a key, this is the order I came up with:


animation
animation-name
animation-duration
animation-timing-function
animation-delay
animation-iteration-count
animation-direction
animation-fill-mode
animation-play-state